### PR TITLE
Tweak the clinician/patient text

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -56,9 +56,9 @@
         <div class="explainer-text">
           <div class="column">
             <p>
-              Medindex is a digital platform which enables clinicians to quickly
-              access information on clinical guidance, pathways and services
-              within a 10 minute patient consultation.
+              Medindex is a digital platform which enables clinicians and patients to
+              quickly access information on clinical guidance, pathways and services
+              within a 10 minute consultation.
             </p>
           </div>
           <div class="column">
@@ -99,7 +99,7 @@
             </li>
             <li>
               <img src="/img/people-group.svg" width="48" />
-              Option to include patient facing content to support population
+              Patient-facing content to support population
               health and self-management
             </li>
           </ul>


### PR DESCRIPTION
The changes I would like to make are adding 'and patients' to the intro text and removing 'patient' from before consultation, and removing 3 words from one of the key feature icons (the last one):

> Medindex is a digital platform which enables clinicians _and patients_ to quickly access information on clinical guidance, pathways and services within a 10 minute ~patient~ consultation.
> 
> ~Option to include~ patient facing content to support population health and self-management.