### PR TITLE
Decommission HPAL MSE

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -949,9 +949,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001620",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001620.tgz",
-      "integrity": "sha512-WJvYsOjd1/BYUY6SNGUosK9DUidBPDTnOARHp3fSmFO1ekdxaY6nKRttEVrfMmYi80ctS0kz1wiWmm14fVc3ew==",
+      "version": "1.0.30001781",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001781.tgz",
+      "integrity": "sha512-RdwNCyMsNBftLjW6w01z8bKEvT6e/5tpPVEgtn22TiLGlstHOVecsX2KHFkD5e/vRnIE4EGzpuIODb3mtswtkw==",
       "dev": true,
       "funding": [
         {
@@ -6670,9 +6670,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001620",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001620.tgz",
-      "integrity": "sha512-WJvYsOjd1/BYUY6SNGUosK9DUidBPDTnOARHp3fSmFO1ekdxaY6nKRttEVrfMmYi80ctS0kz1wiWmm14fVc3ew==",
+      "version": "1.0.30001781",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001781.tgz",
+      "integrity": "sha512-RdwNCyMsNBftLjW6w01z8bKEvT6e/5tpPVEgtn22TiLGlstHOVecsX2KHFkD5e/vRnIE4EGzpuIODb3mtswtkw==",
       "dev": true
     },
     "chalk": {

--- a/src/index.html
+++ b/src/index.html
@@ -115,11 +115,6 @@
                 <img src="/img/nwl-ics-logo.png" height="95" />
               </a>
             </li>
-            <li>
-              <a href="https://mse.medindex.co.uk/" target="_blank">
-                <img src="/img/mse-ics-logo.svg" height="72" />
-              </a>
-            </li>
           </ul>
         </div>
       </section>

--- a/src/mse-decommissioned.html
+++ b/src/mse-decommissioned.html
@@ -1,0 +1,105 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="X-UA-Compatible" content="ie=edge" />
+    <title>HPAL — Mid and South Essex | Medindex</title>
+    <link rel="stylesheet" href="/css/main.css" />
+    <style>
+      .decomm-page {
+        min-height: 100vh;
+        background: linear-gradient(180deg, rgba(0, 0, 0, 0.15) 0%, rgba(0, 0, 0, 0) 40%), #005EB8;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        padding: 4rem 2rem;
+      }
+      .decomm-page__logo {
+        margin-bottom: 3.5rem;
+      }
+      .decomm-page__card {
+        box-sizing: border-box;
+        background: white;
+        border-radius: 12px;
+        box-shadow: 0 8px 30px rgba(0, 0, 0, 0.2);
+        max-width: 60rem;
+        width: 90%;
+        padding: 5rem;
+        text-align: center;
+      }
+      .decomm-page__card h1 {
+        font-size: 2.2rem;
+        color: #005EB8;
+        margin: 0 0 2.5rem;
+        line-height: 1.4;
+        font-weight: 700;
+      }
+      .decomm-page__card p {
+        font-size: 1.7rem;
+        line-height: 1.7;
+        color: #444;
+        margin: 0 0 1.8rem;
+      }
+      .decomm-page__card p:last-of-type {
+        margin-bottom: 0;
+      }
+      .decomm-page__card a {
+        color: #005EB8;
+      }
+      .decomm-page__divider {
+        border: none;
+        border-top: 1px solid #e0e7ef;
+        margin: 3rem auto;
+        max-width: 12rem;
+      }
+      .decomm-page__footer {
+        margin-top: 3.5rem;
+      }
+      .decomm-page__footer img {
+        opacity: 0.4;
+        transition: opacity 0.2s;
+      }
+      .decomm-page__footer a:hover img {
+        opacity: 0.7;
+      }
+      @media only screen and (max-width: 600px) {
+        .decomm-page__card {
+          box-sizing: border-box;
+          padding: 2.5rem 2rem;
+        }
+        .decomm-page__card h1 {
+          font-size: 2rem;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <main class="decomm-page">
+      <div class="decomm-page__logo">
+        <img src="/assets/medindex-logotype-white.svg" height="36" alt="Medindex" />
+      </div>
+
+      <div class="decomm-page__card">
+        <h1>HPAL is no longer commissioned for Mid&nbsp;and&nbsp;South&nbsp;Essex</h1>
+        <p>
+          For palliative care information in Essex please
+          <a href="https://essexicb.nhs.uk" target="_blank">click here</a>.
+        </p>
+        <hr class="decomm-page__divider" />
+        <p>
+          For providers and commissioners interested in tailoring HPAL to their area
+          please contact <a href="https://medindex.co.uk" target="_blank">Medindex</a> or
+          <a href="https://www.harlingtonhospice.org/" target="_blank">Harlington Hospice</a>.
+        </p>
+      </div>
+
+      <div class="decomm-page__footer">
+        <a href="https://medindex.co.uk">
+          <img src="/assets/medindex-circular-m-logo_blue-on-white.svg" height="48" alt="Medindex" />
+        </a>
+      </div>
+    </main>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- Removes the Mid and South Essex ICS link and logo from the Current Platforms section on the homepage
- Adds a decommissioned landing page at `/mse-decommissioned` directing visitors to Essex ICB for palliative care information, and providing contact details for providers/commissioners interested in HPAL
- Updates package-lock.json

## Test plan
- [x] Verify the homepage no longer shows the MSE platform link
- [x] Verify `/mse-decommissioned` renders correctly and all links work (Essex ICB, Medindex, Harlington Hospice)
- [x] Verify the footer Medindex logo links to medindex.co.uk
- [x] Check responsive layout on mobile viewports

## Dependencies
> [!NOTE]
> The following PRs should also be merged (in order) to leverage this change.
- https://github.com/medindex-ltd/infra-deploy/pull/80
- https://github.com/medindex-ltd/infra/pull/2